### PR TITLE
fix for newer join() method in node >= 0.6

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -185,7 +185,7 @@ var commands = {
  */
 
 function pad(n) {
-  return Array(4 - n.toString().length).join('0') + n;
+  return Array(join((4 - n.toString().length), '0') + n);
 }
 
 /**


### PR DESCRIPTION
This should be the only thing stopping it working on newer versions on node if you keep it using sequential migration numbers instead of timestamps. ref #6
