### PR TITLE
"migrate create" doesn't work unless --chdir is supplied

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -24,7 +24,7 @@ var options = { args: [] };
  * Current working directory.
  */
 
-var cwd;
+var cwd = process.cwd();
 
 /**
  * Usage information.


### PR DESCRIPTION
I patched the cwd var to init with the process.cwd().
