### PR TITLE
Bugfix for v0.10.*

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -24,7 +24,7 @@ var options = { args: [] };
  * Current working directory.
  */
 
-var cwd;
+var cwd = '';
 
 /**
  * Usage information.


### PR DESCRIPTION
path.js:360
        throw new TypeError('Arguments to path.join must be strings');
              ^
TypeError: Arguments to path.join must be strings
    at path.js:360:15
    at Array.filter (native)
    at exports.join (path.js:358:36)
    at create (/usr/local/lib/node_modules/migrate/bin/migrate:200:17)
    at Object.commands.create (/usr/local/lib/node_modules/migrate/bin/migrate:176:5)
    at Object.<anonymous> (/usr/local/lib/node_modules/migrate/bin/migrate:240:9)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
