### PR TITLE
Hotfix for node.js v0.10

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -24,7 +24,7 @@ var options = { args: [] };
  * Current working directory.
  */
 
-var cwd;
+var cwd = '';
 
 /**
  * Usage information.


### PR DESCRIPTION
☂ Cwd is now a constant string. Starting with version node.js v0.10, path.join throws an exception if one of the arguments is not a string
