### PR TITLE
CLI Supports Mixins with `--use` flag

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,7 @@ Options:
 
    -c, --chdir <path>   change the working directory
    --state-file <path>  set path to state file (migrations/.migrate)
+   --use <path>         use mixin module at <path>
 
 Commands:
 

--- a/Readme.md
+++ b/Readme.md
@@ -111,6 +111,14 @@ This will run up-migrations upto (and including) `1316027433425-coolest-pet.js`.
     down : migrations/1316027432512-add-jane.js
     migration : complete
 
+## Migration Mixins
+
+The `node-migrate` CLI is extensible via the `--use path/to/mixin.js` flag and mixin modules. Mixins are functions that will be passed `require('migrate')` before `require('migrate').set.migrate()` is invoked. Use this to alter the behavior of the migration Set.
+
+Known mixins:
+
+* [migrate-mongodb-persistence](https://github.com/gobengo/node-migrate-mongodb-persistence): Store migration state in MongoDB instead of a file. POC of a resolution to [node-migrate issue #29](https://github.com/tj/node-migrate/issues/29).
+
 ## License
 
 (The MIT License)

--- a/bin/migrate
+++ b/bin/migrate
@@ -18,7 +18,7 @@ var args = process.argv.slice(2);
  * Option defaults.
  */
 
-var options = { args: [] };
+var options = { args: [], use: [] };
 
 /**
  * Current working directory.
@@ -38,6 +38,7 @@ var usage = [
   , ''
   , '     -c, --chdir <path>   change the working directory'
   , '     --state-file <path>  set path to state file (migrations/.migrate)'
+  , '     --use <path>         use mixin module at <path>'
   , ''
   , '  Commands:'
   , ''
@@ -95,6 +96,9 @@ while (args.length) {
       break;
     case '--state-file':
       options.stateFile = required();
+      break;
+    case '--use':
+      options.use.push(required());
       break;
     default:
       if (options.command) {
@@ -193,6 +197,13 @@ function create(name) {
 
 function performMigration(direction, migrationName) {
   migrate(options.stateFile || join('migrations', '.migrate'));
+
+  options.use.forEach(function (mixinPath) {
+    var mixinPath = require('path').join(process.cwd(), mixinPath);
+    var mixin = require(mixinPath);
+    migrate = mixin(migrate) || migrate;
+  });
+
   migrations().forEach(function(path){
     var mod = require(process.cwd() + '/' + path);
     migrate(path, mod.up, mod.down);


### PR DESCRIPTION
Make the CLI extensible via a `--use path/to/mixin.js` flag and mixin modules. Mixins are functions that will be passed `require('migrate')` before `require('migrate').set.migrate()` is invoked. Use this to alter the behavior of the migration Set.

This adds a point of extensibility to allow projects to customize the behavior of migrate without having to create their own cli script.

I created an initial mixin, [node-migrate-mongodb-persistence](https://github.com/gobengo/node-migrate-mongodb-persistence), that resolves issue #29, at least for others using MongoDB. There's no reason a similar mixin library couldn't be made for other storage engines.

Thoughts? 
