### PR TITLE
Fixed path for comparing filename for named migrations. 

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -195,7 +195,7 @@ function performMigration(direction, migrationName) {
     ? join('migrations', migrationName)
     : migrationName;
 
-  set[direction](migrationPath, function (err) {
+  set[direction](migrationName, function (err) {
     if (err) {
       log('error', err);
       process.exit(1);


### PR DESCRIPTION
The comparison was being done between the absolute path, including the base path and the filename. Now just passing the filename for comparison. 