### PR TITLE
Supporting custom implementations of state persistance.

### DIFF
--- a/lib/set.js
+++ b/lib/set.js
@@ -11,6 +11,7 @@
 
 var EventEmitter = require('events').EventEmitter
   , Migration = require('./migration')
+  , StateFile = require('./stateFile')
   , fs = require('fs');
 
 /**
@@ -27,9 +28,14 @@ module.exports = Set;
  * @api private
  */
 
-function Set(path) {
+function Set(state) {
+  if (typeof state === 'string') {
+    this.state = new StateFile(state);
+  } else {
+    this.state = state;
+  }
+
   this.migrations = [];
-  this.path = path;
   this.pos = 0;
 };
 
@@ -61,11 +67,9 @@ Set.prototype.addMigration = function(title, up, down){
 Set.prototype.save = function(fn){
   var self = this
     , json = JSON.stringify(this);
-  fs.writeFile(this.path, json, function(err){
-    if (err) return fn(err);
-
+  this.state.save(json, function (err) {
     self.emit('save');
-    fn(null);
+    fn(err);
   });
 };
 
@@ -79,14 +83,7 @@ Set.prototype.save = function(fn){
 
 Set.prototype.load = function(fn){
   this.emit('load');
-  fs.readFile(this.path, 'utf8', function(err, json){
-    if (err) return fn(err);
-    try {
-      fn(null, JSON.parse(json));
-    } catch (err) {
-      fn(err);
-    }
-  });
+  this.state.load(fn);
 };
 
 /**

--- a/lib/set.js
+++ b/lib/set.js
@@ -65,9 +65,8 @@ Set.prototype.addMigration = function(title, up, down){
  */
 
 Set.prototype.save = function(fn){
-  var self = this
-    , json = JSON.stringify(this);
-  this.state.save(json, function (err) {
+  var self = this;
+  this.state.save(this, function (err) {
     self.emit('save');
     fn(err);
   });

--- a/lib/set.js
+++ b/lib/set.js
@@ -66,7 +66,9 @@ Set.prototype.addMigration = function(title, up, down){
 
 Set.prototype.save = function(fn){
   var self = this;
-  this.state.save(this, function (err) {
+  this.state.save({
+    pos: self.pos
+  }, function (err) {
     self.emit('save');
     fn(err);
   });

--- a/lib/set.js
+++ b/lib/set.js
@@ -21,10 +21,12 @@ var EventEmitter = require('events').EventEmitter
 module.exports = Set;
 
 /**
- * Initialize a new migration `Set` with the given `path`
- * which is used to store data between migrations.
+ * Initialize a new migration `Set` with the given `path` which is used to store
+ * data between migrations. Alternatively you can provide an implementation
+ * similar to the StateFile class that will persist the state between migrations
+ * in another way.
  *
- * @param {String} path
+ * @param {String} path | {State}
  * @api private
  */
 

--- a/lib/stateFile.js
+++ b/lib/stateFile.js
@@ -4,6 +4,14 @@ function StateFile(path) {
     this.path = path;
 }
 
+/**
+ * A method for loading state. This method will be called with only one
+ * argument; a callback.
+ *
+ * The callback is a standard node.js callback, that takes an error as the first
+ * argument, and the loaded state as the second argument. The state must be
+ * returned as a plain javascript object.
+ */
 StateFile.prototype.load = function (cb) {
     fs.readFile(this.path, 'utf8', function (err, text) {
         if (err) return cb(err);
@@ -15,6 +23,14 @@ StateFile.prototype.load = function (cb) {
     });
 };
 
+/**
+ * A method for saving state. This method will be called with two arguments.
+ *
+ * - an object with the state that will need to be persisted.
+ * - a callback
+ *
+ * The callback takes an error as the only argument.
+ */
 StateFile.prototype.save = function (state, cb) {
     var json = JSON.stringify(state);
     fs.writeFile(this.path, json, function (err) {

--- a/lib/stateFile.js
+++ b/lib/stateFile.js
@@ -1,0 +1,25 @@
+var fs = require('fs');
+
+function StateFile(path) {
+    this.path = path;
+}
+
+StateFile.prototype.load = function (cb) {
+    fs.readFile(this.path, 'utf8', function (err, text) {
+        if (err) return cb(err);
+        try {
+            cb(null, JSON.parse(text));
+        } catch (e) {
+            cb(e);
+        }
+    });
+};
+
+StateFile.prototype.save = function (json, cb) {
+    fs.writeFile(this.path, json, function (err) {
+        if (err) return cb(err);
+        cb(null);
+    });
+};
+
+module.exports = StateFile;

--- a/lib/stateFile.js
+++ b/lib/stateFile.js
@@ -15,7 +15,8 @@ StateFile.prototype.load = function (cb) {
     });
 };
 
-StateFile.prototype.save = function (json, cb) {
+StateFile.prototype.save = function (state, cb) {
+    var json = JSON.stringify(state);
     fs.writeFile(this.path, json, function (err) {
         if (err) return cb(err);
         cb(null);


### PR DESCRIPTION
Ref: #29

This PR seperates the save and load logic from the Set class. The Set can now be instantiated with either a path to the migration file, or a custom implementation of a way to persist state.

The original programmatic use will still work as it always did.

``` js
var migrate = require('migrate');
var set = migrate.load('migration/.migrate', 'migration');
```

But now you can do:

``` js
var migrate = require('migrate');
var set = migrate.load({
    save: function () {},
    load: function () {}
}, 'migration');
```

How to wire this in to the CLI is an open question. I imagine that a new --state parameter could be added which would need to point to a .js file that exported an object that could be used instead of the path, as the argument to the Set constructor.
