### PR TITLE
adding fuzzy matching

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ Options:
    -c, --chdir <path>      change the working directory
    --state-file <path>     set path to state file (migrations/.migrate)
    --template-file <path>  set path to template file to use for new migrations
+   --fuzzy                 make fuzzy comparison for given migrations
 
 Commands:
 
@@ -123,6 +124,25 @@ This will run up-migrations upto (and including) `1316027433425-coolest-pet.js`.
     down : migrations/1316027432575-add-owners.js
     down : migrations/1316027432512-add-jane.js
     migration : complete
+
+### Fuzzy matching
+
+By using the `--fuzzy` flag, you can apply all migrations up/down to a arbitary value that compares to the migration filenames, for example you can migrate all migrations up to a certain date.
+
+    $ migrate up --fuzzy 1316027433000
+    up : migrations/1316027432511-add-pets.js
+    up : migrations/1316027432512-add-jane.js
+    up : migrations/1316027432575-add-owners.js
+
+but it won't add `migrations/1316027433425-coolest-pet.js` to the set as it's value is higer than the given value in a comparison.
+
+Same goes for down migrations:
+
+    $ migrate down --fuzzy 1316027432520
+    down : migrations/1316027433425-coolest-pet.js
+    down : migrations/1316027432575-add-owners.js
+
+It won't apply down on `migrations/1316027432512-add-jane.js` as it's below the target value.
 
 ## API
 

--- a/bin/migrate
+++ b/bin/migrate
@@ -18,7 +18,7 @@ var args = process.argv.slice(2);
  * Option defaults.
  */
 
-var options = { args: [] };
+var options = { args: [], fuzzy: false };
 
 /**
  * Current working directory.
@@ -39,6 +39,7 @@ var usage = [
   , '     -c, --chdir <path>      change the working directory'
   , '     --state-file <path>     set path to state file (migrations/.migrate)'
   , '     --template-file <path>  set path to template file to use for new migrations'
+  , '     --fuzzy                 make fuzzy comparison for given migrations'
   , '  Commands:'
   , ''
   , '     down   [name]    migrate down till given migration'
@@ -99,6 +100,9 @@ while (args.length) {
       break;
     case '--template-file':
       template = fs.readFileSync(required());
+      break;
+    case '--fuzzy':
+      options.fuzzy = true;
       break;
     default:
       if (options.command) {
@@ -195,7 +199,7 @@ function performMigration(direction, migrationName) {
     ? join('migrations', migrationName)
     : migrationName;
 
-  set[direction](migrationName, function (err) {
+  set[direction](migrationName, options.fuzzy, function (err) {
     if (err) {
       log('error', err);
       process.exit(1);

--- a/lib/set.js
+++ b/lib/set.js
@@ -96,8 +96,12 @@ Set.prototype.load = function(fn){
  * @api public
  */
 
-Set.prototype.down = function(migrationName, fn){
-  this.migrate('down', migrationName, fn);
+Set.prototype.down = function(migrationName, fuzzy, fn){
+  if(typeof fuzzy !== 'boolean') {
+    fn = fuzzy;
+    fuzzy = false;
+  }
+  this.migrate('down', migrationName, fuzzy, fn);
 };
 
 /**
@@ -107,8 +111,12 @@ Set.prototype.down = function(migrationName, fn){
  * @api public
  */
 
-Set.prototype.up = function(migrationName, fn){
-  this.migrate('up', migrationName, fn);
+Set.prototype.up = function (migrationName, fuzzy, fn) {
+  if (typeof fuzzy !== 'boolean') {
+    fn = fuzzy;
+    fuzzy = false;
+  }
+  this.migrate('up', migrationName, fuzzy, fn);
 };
 
 /**
@@ -119,7 +127,7 @@ Set.prototype.up = function(migrationName, fn){
  * @api public
  */
 
-Set.prototype.migrate = function(direction, migrationName, fn){
+Set.prototype.migrate = function(direction, migrationName, fuzzy, fn){
   if (typeof migrationName === 'function') {
     fn = migrationName;
     migrationName = null;
@@ -131,7 +139,7 @@ Set.prototype.migrate = function(direction, migrationName, fn){
     } else {
       self.pos = obj.pos;
     }
-    self._migrate(direction, migrationName, fn);
+    self._migrate(direction, migrationName, fuzzy, fn);
   });
 };
 
@@ -139,29 +147,29 @@ Set.prototype.migrate = function(direction, migrationName, fn){
  * Get index of given migration in list of migrations
  *
  * @api private
- */
+*/
 
- function positionOfMigration(migrations, filename) {
-   for(var i=0; i < migrations.length; ++i) {
-     if (migrations[i].title == filename) return i;
-   }
-   return -1;
- }
-
+function positionOfMigration(migrations, fuzzy, filename) {
+  for (var i = 0; i < migrations.length; ++i) {
+    if (migrations[i].title == filename) return i;
+    if (fuzzy && migrations[i].title >= filename) return i;
+  }
+  return -1;
+}
 /**
  * Perform migration.
  *
  * @api private
  */
 
-Set.prototype._migrate = function(direction, migrationName, fn){
+Set.prototype._migrate = function(direction, migrationName, fuzzy, fn){
   var self = this
     , migrations
     , migrationPos;
 
   if (!migrationName) {
     migrationPos = direction == 'up' ? this.migrations.length : 0;
-  } else if ((migrationPos = positionOfMigration(this.migrations, migrationName)) == -1) {
+  } else if ((migrationPos = positionOfMigration(this.migrations, fuzzy, migrationName)) == -1) {
     return fn(new Error("Could not find migration: " + migrationName));
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -187,6 +187,19 @@ describe('migrate', function () {
 
   });
 
+  it('should migrate to named migration fuzzy', function (done) {
+    assertNoPets();
+    set.up('3', true, function (err) {
+      assert.ifError(err);
+      assertPets();
+      set.down('2', true, function (err) {
+        assert.ifError(err);
+        assertFirstMigration();
+        done();
+      });
+    });
+  });
+
   afterEach(function (done) {
     db.nuke();
     fs.unlink(STATE, done);


### PR DESCRIPTION
Fuzzy matching is primary for the usecase of be able to migrate up or
down to a arbitary date that might lie inbetween two migrations; for
example when hooking in migration into a deployment system like shipit
and want to be able to rollback only migrations that was added during
that time.
