### PR TITLE
Add missing license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,6 @@
   },
   "scripts": {
     "test": "mocha"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
https://docs.npmjs.com/files/package.json#license

Now when installing:
```
npm info package.json migrate@0.2.2 No license field.
```