### PR TITLE
Add date-format option for new migrations

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ Options:
    -c, --chdir <path>      change the working directory
    --state-file <path>     set path to state file (migrations/.migrate)
    --template-file <path>  set path to template file to use for new migrations
+   --date-format <format>  set a date format to use for new migration filenames
 
 Commands:
 

--- a/bin/migrate
+++ b/bin/migrate
@@ -6,7 +6,8 @@
 
 var migrate = require('../')
   , join = require('path').join
-  , fs = require('fs');
+  , fs = require('fs')
+  , dateFormat = require('dateformat');
 
 /**
  * Arguments.
@@ -39,6 +40,7 @@ var usage = [
   , '     -c, --chdir <path>      change the working directory'
   , '     --state-file <path>     set path to state file (migrations/.migrate)'
   , '     --template-file <path>  set path to template file to use for new migrations'
+  , '     --date-format <format>  set a date format to use for new migration filenames'
   , '  Commands:'
   , ''
   , '     down   [name]    migrate down till given migration'
@@ -100,6 +102,9 @@ while (args.length) {
     case '--template-file':
       template = fs.readFileSync(required());
       break;
+    case '--date-format':
+      options.dateFormat = required();
+      break;
     default:
       if (options.command) {
         options.args.push(arg);
@@ -160,6 +165,9 @@ var commands = {
   create: function(){
     var curr = Date.now()
       , title = slugify([].slice.call(arguments).join(' '));
+    if (options.dateFormat) {
+      curr = dateFormat(curr, options.dateFormat);
+    }
     title = title ? curr + '-' + title : curr;
     create(title);
   }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "scripts": {
     "test": "mocha"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "dateformat": "^1.0.12"
+  }
 }


### PR DESCRIPTION
I wanted the **create** command to generate more human-readable filenames (similar to what [Phinx does for PHP](http://docs.phinx.org/en/latest/migrations.html#creating-a-new-migration)).

Now, executing `migrate create test --date-format yyyy-mm-dd` will create a file named **2016-07-05-test.js** (rather than something like **1467719501153-test.js**)