### PR TITLE
Add mongodb persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .migrate
 
 migrations/
+.idea/

--- a/bin/migrate
+++ b/bin/migrate
@@ -41,6 +41,7 @@ var usage = [
   , '     --state-file <path>     set path to state file (migrations/.migrate)'
   , '     --template-file <path>  set path to template file to use for new migrations'
   , '     --date-format <format>  set a date format to use for new migration filenames'
+  , '     --state-db <format>     name of env variable containing the mongo connection string for state storage (MONGO_CONNECTION_STRING)'
   , '  Commands:'
   , ''
   , '     down   [name]    migrate down till given migration'
@@ -105,6 +106,9 @@ while (args.length) {
     case '--date-format':
       options.dateFormat = required();
       break;
+    case '--state-db':
+      options.stateDb = required();
+      break;
     default:
       if (options.command) {
         options.args.push(arg);
@@ -119,7 +123,7 @@ while (args.length) {
  */
 
 function log(key, msg) {
-  console.log('  \033[90m%s :\033[0m \033[36m%s\033[0m', key, msg);
+  console.log('  \x1B[90m%s :\x1B[0m \x1B[36m%s\x1B[0m', key, msg);
 }
 
 /**
@@ -133,7 +137,7 @@ function slugify(str) {
 // create ./migrations
 
 try {
-  fs.mkdirSync('migrations', 0774);
+  fs.mkdirSync('migrations', 0o774);
 } catch (err) {
   // ignore
 }
@@ -192,8 +196,9 @@ function create(name) {
  */
 
 function performMigration(direction, migrationName) {
-  var state = options.stateFile || join('migrations', '.migrate');
-  var set = migrate.load(state, 'migrations');
+  var type = options.stateDb ? 'mongo' : 'file';
+  var state = options.stateDb || options.stateFile || join('migrations', '.migrate');
+  var set = migrate.load(state, 'migrations', type);
 
   set.on('migration', function(migration, direction){
     log(direction, migration.title);

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -35,9 +35,11 @@ function migrate(title, up, down) {
   }
 }
 
-exports.load = function (stateFile, migrationsDirectory) {
+var MongoSet = require('./mongo-set');
 
-  var set = new Set(stateFile);
+exports.load = function (stateSrc, migrationsDirectory, type) {
+  type = type || 'file';
+  var set = type === 'file' ? new Set(stateSrc) : new MongoSet(stateSrc);
   var dir = path.resolve(migrationsDirectory);
 
   fs.readdirSync(dir).filter(function(file){

--- a/lib/mongo-set.js
+++ b/lib/mongo-set.js
@@ -1,0 +1,31 @@
+var Set = require('./set');
+var mongo = require('promised-mongo');
+
+function MongoSet(connectionStringEnv, migrationCollection) {
+  Set.call(this, 'mongo');
+  this.connectionString = process.env[connectionStringEnv];
+  this.migrationCollection = migrationCollection || 'migrations';
+}
+
+MongoSet.prototype = Object.create(Set.prototype);
+MongoSet.prototype.constructor = MongoSet;
+
+MongoSet.prototype.load = function(fn) {
+  this.emit('load');
+  var migrations = mongo(this.connectionString)[this.migrationCollection];
+  migrations.findOne({})
+    .then(res => fn(null, res || {}))
+    .catch(fn);
+};
+
+MongoSet.prototype.save = function(fn) {
+  this.emit('load');
+  var migrations = mongo(this.connectionString)[this.migrationCollection];
+  var json = JSON.parse(JSON.stringify(this));
+  migrations
+    .update({}, json, { upsert: true })
+    .then(res => fn(null, res || {}))
+    .catch(fn);
+};
+
+module.exports = MongoSet;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Abstract migration framework for node",
   "keywords": [
     "migrate",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "dateformat": "^1.0.12"
+    "dateformat": "^1.0.12",
+    "promised-mongo": "*"
   }
 }


### PR DESCRIPTION
Added `--state-db` option which contains the name of env variable where DB connection string is stored.

For example `--state-db MONGO_DB_CONNECTION_STRING` means that connection string for DB is stored in `process.env.MONGO_DB_CONNECTION_STRING`.

Added a wildcard dependancy for promised-mongo because any version of promised-mongo contains the functionality required for this PR.

Connection string is deliberately not read from the argument directly because usually server environments pass connection string as an env var.