### PR TITLE
Fix documentation as relates to registering a compiler.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -145,8 +145,8 @@ use the `comipler` flag.  For example, to use babel with your migrations, you ca
 
 ```
 $ npm install --save babel-register
-$ migrate create --compiler=".js:babel-register" foo
-$ migrate up --compiler=".js:babel-register"
+$ migrate create --compiler="js:babel-register" foo
+$ migrate up --compiler="js:babel-register"
 ```
 
 ## Running Migrations


### PR DESCRIPTION
The extension specified should not include the dot (.), as it is added by the library. See: https://github.com/tj/node-migrate/blob/master/lib/register-compiler.js#L13
