### PR TITLE
Resolve project-relative store path relative to CWD.

### DIFF
--- a/bin/migrate-down
+++ b/bin/migrate-down
@@ -43,6 +43,8 @@ if (program.compiler) {
 }
 
 // Setup store
+if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
+
 var Store = require(program.store)
 var store = new Store(program.stateFile)
 

--- a/bin/migrate-init
+++ b/bin/migrate-init
@@ -32,6 +32,8 @@ if (program.env) {
 }
 
 // Setup store
+if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
+
 var Store = require(program.store)
 var store = new Store(program.stateFile)
 

--- a/bin/migrate-list
+++ b/bin/migrate-list
@@ -50,6 +50,8 @@ if (program.compiler) {
 }
 
 // Setup store
+if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
+
 var Store = require(program.store)
 var store = new Store(program.stateFile)
 

--- a/bin/migrate-up
+++ b/bin/migrate-up
@@ -58,6 +58,8 @@ if (program.compiler) {
 }
 
 // Setup store
+if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
+
 var Store = require(program.store)
 var store = new Store(program.stateFile)
 


### PR DESCRIPTION
Currently, if a user defined a store within their project, and loads in a-la `migrate up --store=./db/Store.js`, the command will fail because `migrate` attempts to resolve the path relative to the `migrate` module.

Resolution of the store should be handled the same as resolution of a relative path for a compiler (see: https://github.com/tj/node-migrate/blob/master/lib/register-compiler.js#L11).