### PR TITLE
Add explicit exit upon completion of 'list' command.

### DIFF
--- a/bin/migrate-list
+++ b/bin/migrate-list
@@ -71,4 +71,6 @@ migrate.load({
   set.migrations.forEach(function (migration) {
     log(migration.title + (migration.timestamp ? ' [' + dateFormat(migration.timestamp, program.dateFormat) + ']' : ' [not run]'), migration.description || '<No Description>')
   })
+
+  process.exit(0)
 })


### PR DESCRIPTION
Without this explicit exit, if a database store is used to persist migration state (and database connections are open during script execution), the script never exits. There is no other mechanism in this library to signal to the custom store that work is complete.

The explicit call to `process.exit(0)` added here is consistent with the implementation of the `up` and `down` commands. See:
- https://github.com/tj/node-migrate/blob/master/bin/migrate-up#L101
- https://github.com/tj/node-migrate/blob/master/bin/migrate-down#L71