### PR TITLE
Restore CLI argument "extention" but mark as deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .migrate
 test/fixtures/tmp
 *.swp
+yarn-error.log
+yarn.lock

--- a/bin/migrate-create
+++ b/bin/migrate-create
@@ -17,11 +17,17 @@ program
   .option('-d, --date-format [format]', 'Set a date format to use')
   .option('-t, --template-file [filePath]', 'Set path to template file to use for new migrations', path.join(__dirname, '..', 'lib', 'template.js'))
   .option('-e, --extension [extension]', 'Use the given extension to create the file', '.js')
+  .option('--extention [extension]', '. Use the given extension to create the file. Deprecated as of v1.2. Replace with -e or --extension.', '.js')
   .option('-g, --generator <name>', 'A template generator function', path.join(__dirname, '..', 'lib', 'template-generator'))
   .option('--env [name]', 'Use dotenv to load an environment file')
   .arguments('<name>')
   .action(create)
   .parse(process.argv)
+
+if (program.extention) {
+  console.log('create', '"--extention" argument is deprecated. Use "--extension" instead')
+  program.extension = program.extension
+}
 
 // Setup environment
 if (program.env) {


### PR DESCRIPTION
CLI argument "extension" was replaced with correctly spelled "extension' in #110. We need to restore support the old misspelled argument (deprecated for now) so as not to break the public interface.