### PR TITLE
CI/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - stable
+  - "node"


### PR DESCRIPTION
This fixes issue #116.

Config is rather simple; it runs tests using the stable version of Node.

Admin needs to enable Travis for this repo for the builds to be triggered automatically.