### PR TITLE
Fix missing migration index

### DIFF
--- a/bin/migrate-down
+++ b/bin/migrate-down
@@ -22,6 +22,7 @@ program
   .option('--matches <glob>', 'A glob pattern to filter migration files', '*')
   .option('--compiler <ext:module>', 'Use the given module to compile files')
   .option('--env [name]', 'Use dotenv to load an environment file')
+  .option('-F, --force', 'Force through the command, ignoring warnings')
   .parse(process.argv)
 
 // Change the working dir
@@ -52,7 +53,8 @@ var store = new Store(program.stateFile)
 migrate.load({
   stateStore: store,
   migrationsDirectory: program.migrationsDir,
-  filterFunction: minimatch.filter(program.matches)
+  filterFunction: minimatch.filter(program.matches),
+  ignoreMissing: program.force
 }, function (err, set) {
   if (err) {
     log.error('error', err)

--- a/bin/migrate-up
+++ b/bin/migrate-up
@@ -19,7 +19,7 @@ program
   .option('-f, --state-file <path>', 'Set path to state file', '.migrate')
   .option('-s, --store <store>', 'Set the migrations store', path.join(__dirname, '..', 'lib', 'file-store'))
   .option('--clean', 'Tears down the migration state before running up')
-  .option('--force', 'Force through the command, ignoring warnings')
+  .option('-F, --force', 'Force through the command, ignoring warnings')
   .option('--init', 'Runs init for the store')
   .option('--migrations-dir <dir>', 'Change the migrations directory name', 'migrations')
   .option('--matches <glob>', 'A glob pattern to filter migration files', '*')
@@ -78,7 +78,8 @@ function loadAndGo () {
   migrate.load({
     stateStore: store,
     migrationsDirectory: program.migrationsDir,
-    filterFunction: minimatch.filter(program.matches)
+    filterFunction: minimatch.filter(program.matches),
+    ignoreMissing: program.force
   }, function (err, set) {
     if (err) {
       log.error('error', err)

--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ exports.load = function (options, fn) {
     store: store,
     migrationsDirectory: opts.migrationsDirectory,
     filterFunction: opts.filterFunction,
-    sortFunction: opts.sortFunction
+    sortFunction: opts.sortFunction,
+    ignoreMissing: opts.ignoreMissing
   }, function (err) {
     fn(err, set)
   })

--- a/lib/load-migrations.js
+++ b/lib/load-migrations.js
@@ -14,6 +14,7 @@ function loadMigrationsIntoSet (options, fn) {
   }
   var set = opts.set
   var store = opts.store
+  var ignoreMissing = !!opts.ignoreMissing
   var migrationsDirectory = path.resolve(opts.migrationsDirectory || 'migrations')
   var filterFn = opts.filterFunction || (() => true)
   var sortFn = opts.sortFunction || function (m1, m2) {
@@ -53,8 +54,7 @@ function loadMigrationsIntoSet (options, fn) {
       // Fill in timestamp from state, or error if missing
       state.migrations && state.migrations.forEach(function (m) {
         if (m.timestamp !== null && !migMap[m.title]) {
-          // @TODO is this the best way to handle this?
-          return fn(new Error('Missing migration file: ' + m.title))
+          return ignoreMissing ? null : fn(new Error('Missing migration file: ' + m.title))
         } else if (!migMap[m.title]) {
           // Migration existed in state file, but was not run and not loadable
           return

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -14,6 +14,7 @@ function migrate (set, direction, migrationName, fn) {
   }
 
   lastRunIndex = positionOfMigration(set.migrations, set.lastRun)
+
   migrations = (direction === 'up' ? upMigrations : downMigrations)(set, lastRunIndex, toIndex)
 
   function next (migration) {
@@ -114,8 +115,12 @@ function downMigrations (set, lastRunIndex, toIndex) {
  */
 
 function positionOfMigration (migrations, title) {
+  var lastTimestamp
   for (var i = 0; i < migrations.length; ++i) {
+    lastTimestamp = migrations[i].timestamp ? i : lastTimestamp
     if (migrations[i].title === title) return i
   }
-  return -1
+
+  // If titled migration was missing use last timestamped
+  return lastTimestamp
 }


### PR DESCRIPTION
When the state file contains a migration which was run up on a different branch, but no longer exists in the current branch, it currently errors and there is no way around it, even if you know you just want to run it down.  Now you can pass `--force` and it will try anyway.

There is also a bug fix which happened in this scenario where `lastRunIndex` was `-1`.