### PR TITLE
Shows better error msg on SyntaxError

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -7,4 +7,7 @@ module.exports = function log (key, msg) {
 
 module.exports.error = function log (key, msg) {
   console.error('  ' + chalk.red(key) + ' : ' + chalk.white(msg))
+  if (msg instanceof Error) {
+    console.error(msg)
+  }
 }


### PR DESCRIPTION
Currently if we have a syntax error in a migration the console output won't display meaningful information like stack trace, file and line number of the error. 

This PR fixes it