### PR TITLE
`migrate(title)` when title is a `string` fails on line 48 

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function migrate (title, up, down) {
     migrate.set.addMigration(title, up, down)
   // specify migration file
   } else if (typeof title === 'string') {
-    migrate.set = exports.load(title)
+    migrate.set = exports.load({ stateStore: title }, up || console.error);
   // no migration path
   } else if (!migrate.set) {
     throw new Error('must invoke migrate(path) before running migrations')


### PR DESCRIPTION
Calling `migrate(title)` with title is a `string` fails on line due to `opts.stateStore` being undefined 
- `fn` also may be undefined so needs to be defaulted.
