### PR TITLE
Fix: resolve path for custom generator file.

### DIFF
--- a/bin/migrate-create
+++ b/bin/migrate-create
@@ -53,7 +53,7 @@ function create (name) {
   }
 
   // Load the template generator
-  var gen = require(program.generator)
+  var gen = require(path.resolve(program.generator))
   gen({
     name: name,
     dateFormat: program.dateFormat,


### PR DESCRIPTION
The -g --generator flag for the create script doesn't resolve the correct path for a custom generator file.

Test:
```
npm init
npm install -s migrate
./node_modules/.bin/migrate init
cp node_modules/migrate/lib/template-generator.js custom.js
./node_modules/.bin/migrate create -g ./custom.js test_migration

internal/modules/cjs/loader.js:605
    throw err;
    ^

Error: Cannot find module 'custom.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:603:15)
    at Function.Module._load (internal/modules/cjs/loader.js:529:25)
    at Module.require (internal/modules/cjs/loader.js:658:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Command.create (/Users/andrew/code/migrate_bug/node_modules/migrate/bin/migrate-create:56:13)
    at Command.listener (/Users/andrew/code/migrate_bug/node_modules/commander/index.js:315:8)
    at Command.emit (events.js:182:13)
    at Command.parseArgs (/Users/andrew/code/migrate_bug/node_modules/commander/index.js:656:12)
    at Command.parse (/Users/andrew/code/migrate_bug/node_modules/commander/index.js:474:21)
    at Object.<anonymous> (/Users/andrew/code/migrate_bug/node_modules/migrate/bin/migrate-create:25:4)
```

Fix:
[var gen = require(program.generator)](https://github.com/tj/node-migrate/blob/1485388b18ff9af94889209c683e0c096d77c0ac/bin/migrate-create#L56)
To:
  var gen = require(path.resolve(program.generator))