### PR TITLE
Fix error logging on failed migration

### DIFF
--- a/bin/migrate-down
+++ b/bin/migrate-down
@@ -67,7 +67,7 @@ migrate.load({
 
   runMigrations(set, 'down', program.args[0], function (err) {
     if (err) {
-      log('error', err)
+      log.error('error', err)
       process.exit(1)
     }
 

--- a/bin/migrate-up
+++ b/bin/migrate-up
@@ -97,7 +97,7 @@ function loadAndGo () {
     // Run
     ;(program.clean ? cleanUp : up)(set, function (err) {
       if (err) {
-        log('error', err)
+        log.error('error', err)
         process.exit(1)
       }
       log('migration', 'complete')


### PR DESCRIPTION
The original intent of the `log.error` was to improve this.  It looks like I missed a spot, resulting in the logging really not being helpful.  This fixes that so that now it shows a stack trace if the log is passed an error instance.