### PR TITLE
Improve custom-module load and extend compiler support for multiple extensions

### DIFF
--- a/bin/migrate-create
+++ b/bin/migrate-create
@@ -5,6 +5,7 @@
 var program = require('commander')
 var path = require('path')
 var dotenv = require('dotenv')
+var customRequire = require('../lib/custom-require')
 var log = require('../lib/log')
 var registerCompiler = require('../lib/register-compiler')
 var pkg = require('../package.json')
@@ -53,12 +54,7 @@ function create (name) {
   }
 
   // Load the template generator
-  var gen
-  try {
-    gen = require(program.generator)
-  } catch (e) {
-    gen = require(path.resolve(program.generator))
-  }
+  var gen = customRequire(program.generator)
   gen({
     name: name,
     dateFormat: program.dateFormat,

--- a/bin/migrate-down
+++ b/bin/migrate-down
@@ -6,6 +6,7 @@ var program = require('commander')
 var path = require('path')
 var minimatch = require('minimatch')
 var dotenv = require('dotenv')
+var customRequire = require('../lib/custom-require')
 var migrate = require('../')
 var runMigrations = require('../lib/migrate')
 var log = require('../lib/log')
@@ -44,9 +45,7 @@ if (program.compiler) {
 }
 
 // Setup store
-if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
-
-var Store = require(program.store)
+var Store = customRequire(program.store)
 var store = new Store(program.stateFile)
 
 // Load in migrations

--- a/bin/migrate-init
+++ b/bin/migrate-init
@@ -6,6 +6,7 @@ var program = require('commander')
 var mkdirp = require('mkdirp')
 var dotenv = require('dotenv')
 var path = require('path')
+var customRequire = require('../lib/custom-require')
 var log = require('../lib/log')
 var pkg = require('../package.json')
 var registerCompiler = require('../lib/register-compiler')
@@ -39,9 +40,7 @@ if (program.compiler) {
 }
 
 // Setup store
-if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
-
-var Store = require(program.store)
+var Store = customRequire(program.store)
 var store = new Store(program.stateFile)
 
 // Create migrations dir path

--- a/bin/migrate-list
+++ b/bin/migrate-list
@@ -7,6 +7,7 @@ var path = require('path')
 var dateFormat = require('dateformat')
 var minimatch = require('minimatch')
 var dotenv = require('dotenv')
+var customRequire = require('../lib/custom-require')
 var migrate = require('../')
 var log = require('../lib/log')
 var registerCompiler = require('../lib/register-compiler')
@@ -50,9 +51,7 @@ if (program.compiler) {
 }
 
 // Setup store
-if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
-
-var Store = require(program.store)
+var Store = customRequire(program.store)
 var store = new Store(program.stateFile)
 
 // Load in migrations

--- a/bin/migrate-up
+++ b/bin/migrate-up
@@ -6,6 +6,7 @@ var program = require('commander')
 var path = require('path')
 var minimatch = require('minimatch')
 var dotenv = require('dotenv')
+var customRequire = require('../lib/custom-require')
 var migrate = require('../')
 var runMigrations = require('../lib/migrate')
 var log = require('../lib/log')
@@ -58,9 +59,7 @@ if (program.compiler) {
 }
 
 // Setup store
-if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
-
-var Store = require(program.store)
+var Store = customRequire(program.store)
 var store = new Store(program.stateFile)
 
 // Call store init

--- a/lib/custom-require.js
+++ b/lib/custom-require.js
@@ -1,0 +1,11 @@
+'use strict'
+
+var path = require('path')
+
+module.exports = function customRequire (mod) {
+  try {
+    return require(mod)
+  } catch (e) {
+    return require(path.resolve(mod))
+  }
+}

--- a/lib/register-compiler.js
+++ b/lib/register-compiler.js
@@ -1,5 +1,6 @@
 'use strict'
-var path = require('path')
+
+var customRequire = require('./custom-require')
 
 module.exports = registerCompiler
 
@@ -8,8 +9,7 @@ function registerCompiler (c) {
   var ext = compiler[0]
   var mod = compiler[1]
 
-  if (mod[0] === '.') mod = path.join(process.cwd(), mod)
-  require(mod)({
+  customRequire(mod)({
     extensions: ['.' + ext]
   })
 }

--- a/lib/register-compiler.js
+++ b/lib/register-compiler.js
@@ -6,10 +6,19 @@ module.exports = registerCompiler
 
 function registerCompiler (c) {
   var compiler = c.split(':')
-  var ext = compiler[0]
-  var mod = compiler[1]
 
-  customRequire(mod)({
-    extensions: ['.' + ext]
-  })
+  if (compiler.length === 1) {
+    customRequire(compiler[0])
+  } else if (compiler.length === 2) {
+    var extensions = compiler[0].split(',')
+    var moduleName = compiler[1]
+
+    customRequire(moduleName)({
+      extensions: extensions.map(function (ext) {
+        return '.' + ext
+      })
+    })
+  } else {
+    throw new Error('Invalid compiler format')
+  }
 }


### PR DESCRIPTION
- use same common require-fallback strategy to load user custom-modules (eg. Store and Compiler) 
- extend compiler multiple extensions support eg. `--compiler "js,js6,ts:@babel/register`