### PR TITLE
allow using esm modules in migrations 

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -2,8 +2,8 @@
 // vim: set ft=javascript:
 'use strict'
 
-var program = require('commander')
-var pkg = require('../package.json')
+const program = require('commander')
+const pkg = require('../package.json')
 
 program
   .version(pkg.version)

--- a/bin/migrate-create
+++ b/bin/migrate-create
@@ -2,12 +2,14 @@
 // vim: set ft=javascript:
 'use strict'
 
-var program = require('commander')
-var path = require('path')
-var dotenv = require('dotenv')
-var log = require('../lib/log')
-var registerCompiler = require('../lib/register-compiler')
-var pkg = require('../package.json')
+const program = require('commander')
+const path = require('path')
+const dotenv = require('dotenv')
+const log = require('../lib/log')
+const registerCompiler = require('../lib/register-compiler')
+const pkg = require('../package.json')
+
+let _name
 
 program
   .version(pkg.version)
@@ -24,49 +26,50 @@ program
   .action(create)
   .parse(process.argv)
 
-if (program.extention) {
+const options = program.opts()
+
+if (options.extention) {
   console.log('create', '"--extention" argument is deprecated. Use "--extension" instead')
 }
 
 // Setup environment
-if (program.env) {
-  var e = dotenv.config({
-    path: typeof program.env === 'string' ? program.env : '.env'
+if (options.env) {
+  const e = dotenv.config({
+    path: typeof options.env === 'string' ? options.env : '.env'
   })
   if (e && e.error instanceof Error) {
     throw e.error
   }
 }
 
-var _name
-function create (name) {
+function create (name, options) {
   // Name provided?
   _name = name
 
   // Change the working dir
-  process.chdir(program.chdir)
+  process.chdir(options.chdir)
 
   // Load compiler
-  if (program.compiler) {
-    registerCompiler(program.compiler)
+  if (options.compiler) {
+    registerCompiler(options.compiler)
   }
 
   // Load the template generator
-  var gen
+  let gen
   try {
-    gen = require(program.generator)
+    gen = require(options.generator)
   } catch (e) {
-    gen = require(path.resolve(program.generator))
+    gen = require(path.resolve(options.generator))
   }
   gen({
     name: name,
-    dateFormat: program.dateFormat,
-    templateFile: program.templateFile,
-    migrationsDirectory: program.migrationsDir,
-    extension: program.extension || path.extname(program.templateFile)
+    dateFormat: options.dateFormat,
+    templateFile: options.templateFile,
+    migrationsDirectory: options.migrationsDir,
+    extension: options.extension || path.extname(options.templateFile)
   }, function (err, p) {
     if (err) {
-      log.error('Template generation error', err.message)
+      log.error('Template generation error', err.message || err)
       process.exit(1)
     }
     log('create', p)

--- a/bin/migrate-down
+++ b/bin/migrate-down
@@ -2,15 +2,15 @@
 // vim: set ft=javascript:
 'use strict'
 
-var program = require('commander')
-var path = require('path')
-var minimatch = require('minimatch')
-var dotenv = require('dotenv')
-var migrate = require('../')
-var runMigrations = require('../lib/migrate')
-var log = require('../lib/log')
-var registerCompiler = require('../lib/register-compiler')
-var pkg = require('../package.json')
+const program = require('commander')
+const path = require('path')
+const minimatch = require('minimatch')
+const dotenv = require('dotenv')
+const migrate = require('../')
+const runMigrations = require('../lib/migrate')
+const log = require('../lib/log')
+const registerCompiler = require('../lib/register-compiler')
+const pkg = require('../package.json')
 
 program
   .version(pkg.version)
@@ -25,13 +25,15 @@ program
   .option('-F, --force', 'Force through the command, ignoring warnings')
   .parse(process.argv)
 
+const options = program.opts()
+
 // Change the working dir
-process.chdir(program.chdir)
+process.chdir(options.chdir)
 
 // Setup environment
-if (program.env) {
-  var e = dotenv.config({
-    path: typeof program.env === 'string' ? program.env : '.env'
+if (options.env) {
+  const e = dotenv.config({
+    path: typeof options.env === 'string' ? options.env : '.env'
   })
   if (e && e.error instanceof Error) {
     throw e.error
@@ -39,22 +41,22 @@ if (program.env) {
 }
 
 // Load compiler
-if (program.compiler) {
-  registerCompiler(program.compiler)
+if (options.compiler) {
+  registerCompiler(options.compiler)
 }
 
 // Setup store
-if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
+if (options.store[0] === '.') options.store = path.join(process.cwd(), options.store)
 
-var Store = require(program.store)
-var store = new Store(program.stateFile)
+const Store = require(options.store)
+const store = new Store(options.stateFile)
 
 // Load in migrations
 migrate.load({
   stateStore: store,
-  migrationsDirectory: program.migrationsDir,
-  filterFunction: minimatch.filter(program.matches),
-  ignoreMissing: program.force
+  migrationsDirectory: options.migrationsDir,
+  filterFunction: minimatch.filter(options.matches),
+  ignoreMissing: options.force
 }, function (err, set) {
   if (err) {
     log.error('error', err)

--- a/bin/migrate-init
+++ b/bin/migrate-init
@@ -2,13 +2,13 @@
 // vim: set ft=javascript:
 'use strict'
 
-var program = require('commander')
-var mkdirp = require('mkdirp')
-var dotenv = require('dotenv')
-var path = require('path')
-var log = require('../lib/log')
-var pkg = require('../package.json')
-var registerCompiler = require('../lib/register-compiler')
+const program = require('commander')
+const mkdirp = require('mkdirp')
+const dotenv = require('dotenv')
+const path = require('path')
+const log = require('../lib/log')
+const pkg = require('../package.json')
+const registerCompiler = require('../lib/register-compiler')
 
 program
   .version(pkg.version)
@@ -20,13 +20,15 @@ program
   .option('--env [name]', 'Use dotenv to load an environment file')
   .parse(process.argv)
 
+const options = program.opts()
+
 // Change the working dir
-process.chdir(program.chdir)
+process.chdir(options.chdir)
 
 // Setup environment
-if (program.env) {
-  var e = dotenv.config({
-    path: typeof program.env === 'string' ? program.env : '.env'
+if (options.env) {
+  const e = dotenv.config({
+    path: typeof options.env === 'string' ? options.env : '.env'
   })
   if (e && e.error instanceof Error) {
     throw e.error
@@ -34,18 +36,18 @@ if (program.env) {
 }
 
 // Load compiler
-if (program.compiler) {
-  registerCompiler(program.compiler)
+if (options.compiler) {
+  registerCompiler(options.compiler)
 }
 
 // Setup store
-if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
+if (options.store[0] === '.') options.store = path.join(process.cwd(), options.store)
 
-var Store = require(program.store)
-var store = new Store(program.stateFile)
+const Store = require(options.store)
+const store = new Store(options.stateFile)
 
 // Create migrations dir path
-var p = path.resolve(process.cwd(), program.migrationsDir)
+const p = path.resolve(process.cwd(), options.migrationsDir)
 
 log('migrations dir', p)
 mkdirp.sync(p)

--- a/bin/migrate-list
+++ b/bin/migrate-list
@@ -2,15 +2,15 @@
 // vim: set ft=javascript:
 'use strict'
 
-var program = require('commander')
-var path = require('path')
-var dateFormat = require('dateformat')
-var minimatch = require('minimatch')
-var dotenv = require('dotenv')
-var migrate = require('../')
-var log = require('../lib/log')
-var registerCompiler = require('../lib/register-compiler')
-var pkg = require('../package.json')
+const program = require('commander')
+const path = require('path')
+const dateFormat = require('dateformat')
+const minimatch = require('minimatch')
+const dotenv = require('dotenv')
+const migrate = require('../')
+const log = require('../lib/log')
+const registerCompiler = require('../lib/register-compiler')
+const pkg = require('../package.json')
 
 program
   .version(pkg.version)
@@ -25,19 +25,21 @@ program
   .option('--env [name]', 'Use dotenv to load an environment file')
   .parse(process.argv)
 
+const options = program.opts()
+
 // Check clean flag, exit if NODE_ENV === 'production' and force not specified
-if (program.clean && process.env.NODE_ENV === 'production' && !program.force) {
+if (options.clean && process.env.NODE_ENV === 'production' && !options.force) {
   log.error('error', 'Cowardly refusing to clean while node environment set to production, use --force to continue.')
   process.exit(1)
 }
 
 // Change the working dir
-process.chdir(program.chdir)
+process.chdir(options.chdir)
 
 // Setup environment
-if (program.env) {
-  var e = dotenv.config({
-    path: typeof program.env === 'string' ? program.env : '.env'
+if (options.env) {
+  const e = dotenv.config({
+    path: typeof options.env === 'string' ? options.env : '.env'
   })
   if (e && e.error instanceof Error) {
     throw e.error
@@ -45,21 +47,21 @@ if (program.env) {
 }
 
 // Load compiler
-if (program.compiler) {
-  registerCompiler(program.compiler)
+if (options.compiler) {
+  registerCompiler(options.compiler)
 }
 
 // Setup store
-if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
+if (options.store[0] === '.') options.store = path.join(process.cwd(), options.store)
 
-var Store = require(program.store)
-var store = new Store(program.stateFile)
+const Store = require(options.store)
+const store = new Store(options.stateFile)
 
 // Load in migrations
 migrate.load({
   stateStore: store,
-  migrationsDirectory: program.migrationsDir,
-  filterFunction: minimatch.filter(program.matches)
+  migrationsDirectory: options.migrationsDir,
+  filterFunction: minimatch.filter(options.matches)
 }, function (err, set) {
   if (err) {
     log.error('error', err)
@@ -71,7 +73,7 @@ migrate.load({
   }
 
   set.migrations.forEach(function (migration) {
-    log(migration.title + (migration.timestamp ? ' [' + dateFormat(migration.timestamp, program.dateFormat) + ']' : ' [not run]'), migration.description || '<No Description>')
+    log(migration.title + (migration.timestamp ? ' [' + dateFormat(migration.timestamp, options.dateFormat) + ']' : ' [not run]'), migration.description || '<No Description>')
   })
 
   process.exit(0)

--- a/bin/migrate-up
+++ b/bin/migrate-up
@@ -2,15 +2,15 @@
 // vim: set ft=javascript:
 'use strict'
 
-var program = require('commander')
-var path = require('path')
-var minimatch = require('minimatch')
-var dotenv = require('dotenv')
-var migrate = require('../')
-var runMigrations = require('../lib/migrate')
-var log = require('../lib/log')
-var registerCompiler = require('../lib/register-compiler')
-var pkg = require('../package.json')
+const program = require('commander')
+const path = require('path')
+const minimatch = require('minimatch')
+const dotenv = require('dotenv')
+const migrate = require('../')
+const runMigrations = require('../lib/migrate')
+const log = require('../lib/log')
+const registerCompiler = require('../lib/register-compiler')
+const pkg = require('../package.json')
 
 program
   .version(pkg.version)
@@ -27,13 +27,15 @@ program
   .option('--env [name]', 'Use dotenv to load an environment file')
   .parse(process.argv)
 
+const options = program.opts()
+
 // Change the working dir
-process.chdir(program.chdir)
+process.chdir(options.chdir)
 
 // Setup environment
-if (program.env) {
-  var e = dotenv.config({
-    path: typeof program.env === 'string' ? program.env : '.env'
+if (options.env) {
+  const e = dotenv.config({
+    path: typeof options.env === 'string' ? options.env : '.env'
   })
   if (e && e.error instanceof Error) {
     throw e.error
@@ -41,30 +43,30 @@ if (program.env) {
 }
 
 // Check clean flag, exit if NODE_ENV === 'production' and force not specified
-if (program.clean && process.env.NODE_ENV === 'production' && !program.force) {
+if (options.clean && process.env.NODE_ENV === 'production' && !options.force) {
   log.error('error', 'Cowardly refusing to clean while node environment set to production, use --force to continue.')
   process.exit(1)
 }
 
 // Check init flag, exit if NODE_ENV === 'production' and force not specified
-if (program.init && process.env.NODE_ENV === 'production' && !program.force) {
+if (options.init && process.env.NODE_ENV === 'production' && !options.force) {
   log.error('error', 'Cowardly refusing to init while node environment set to production, use --force to continue.')
   process.exit(1)
 }
 
 // Load compiler
-if (program.compiler) {
-  registerCompiler(program.compiler)
+if (options.compiler) {
+  registerCompiler(options.compiler)
 }
 
 // Setup store
-if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
+if (options.store[0] === '.') options.store = path.join(process.cwd(), options.store)
 
-var Store = require(program.store)
-var store = new Store(program.stateFile)
+const Store = require(options.store)
+const store = new Store(options.stateFile)
 
 // Call store init
-if (program.init && typeof store.init === 'function') {
+if (options.init && typeof store.init === 'function') {
   store.init(function (err) {
     if (err) return log.error(err)
     loadAndGo()
@@ -77,9 +79,9 @@ if (program.init && typeof store.init === 'function') {
 function loadAndGo () {
   migrate.load({
     stateStore: store,
-    migrationsDirectory: program.migrationsDir,
-    filterFunction: minimatch.filter(program.matches),
-    ignoreMissing: program.force
+    migrationsDirectory: options.migrationsDir,
+    filterFunction: minimatch.filter(options.matches),
+    ignoreMissing: options.force
   }, function (err, set) {
     if (err) {
       log.error('error', err)
@@ -95,7 +97,7 @@ function loadAndGo () {
     })
 
     // Run
-    ;(program.clean ? cleanUp : up)(set, function (err) {
+    ; (options.clean ? cleanUp : up)(set, function (err) {
       if (err) {
         log.error('error', err)
         process.exit(1)

--- a/examples/cli/migrations/1316027432511-add-pets.js
+++ b/examples/cli/migrations/1316027432511-add-pets.js
@@ -1,5 +1,5 @@
 
-var db = require('./db')
+const db = require('./db')
 
 exports.up = function (next) {
   db.rpush('pets', 'tobi')

--- a/examples/cli/migrations/1316027432512-add-jane.js
+++ b/examples/cli/migrations/1316027432512-add-jane.js
@@ -1,5 +1,5 @@
 
-var db = require('./db')
+const db = require('./db')
 
 exports.up = function (next) {
   db.rpush('pets', 'jane', next)

--- a/examples/cli/migrations/1316027432575-add-owners.js
+++ b/examples/cli/migrations/1316027432575-add-owners.js
@@ -1,5 +1,5 @@
 
-var db = require('./db')
+const db = require('./db')
 
 exports.up = function (next) {
   db.rpush('owners', 'taylor')

--- a/examples/cli/migrations/1316027433425-coolest-pet.js
+++ b/examples/cli/migrations/1316027433425-coolest-pet.js
@@ -1,5 +1,5 @@
 
-var db = require('./db')
+const db = require('./db')
 
 exports.up = function (next) {
   db.set('pets:coolest', 'tobi', next)

--- a/examples/cli/migrations/db.js
+++ b/examples/cli/migrations/db.js
@@ -4,7 +4,7 @@
 // $ npm install redis
 // $ redis-server
 
-var redis = require('redis')
-var db = redis.createClient()
+const redis = require('redis')
+const db = redis.createClient()
 
 module.exports = db

--- a/examples/custom-state-storage/mongo-state-storage.js
+++ b/examples/custom-state-storage/mongo-state-storage.js
@@ -16,7 +16,7 @@ class MongoDbStore {
         return fn(null, {})
       }
     } catch (err) {
-      throw err
+      return fn(err)
     } finally {
       client.close()
     }
@@ -39,7 +39,7 @@ class MongoDbStore {
           }
         }, { upsert: true })
     } catch (err) {
-      throw err
+      return fn(err)
     } finally {
       client.close()
     }

--- a/examples/env/db.js
+++ b/examples/env/db.js
@@ -1,5 +1,5 @@
 'use strict'
-var fs = require('fs')
+const fs = require('fs')
 
 module.exports = {
   loaded: false,
@@ -25,7 +25,7 @@ module.exports = {
   },
   load: function () {
     if (this.loaded) return this
-    var json
+    let json
     try {
       json = JSON.parse(fs.readFileSync('.db', 'utf8'))
     } catch (e) {

--- a/examples/migrate.js
+++ b/examples/migrate.js
@@ -4,10 +4,10 @@
 // $ npm install redis
 // $ redis-server
 
-var path = require('path')
-var migrate = require('../')
-var redis = require('redis')
-var db = redis.createClient()
+const path = require('path')
+const migrate = require('../')
+const redis = require('redis')
+const db = redis.createClient()
 
 migrate(path.join(__dirname, '.migrate'))
 
@@ -39,7 +39,7 @@ migrate('coolest pet', function (next) {
   db.del('pets:coolest', next)
 })
 
-var set = migrate()
+const set = migrate()
 
 console.log()
 set.on('save', function () {

--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@
  * Module dependencies.
  */
 
-var MigrationSet = require('./lib/set')
-var FileStore = require('./lib/file-store')
-var loadMigrationsIntoSet = require('./lib/load-migrations')
+const MigrationSet = require('./lib/set')
+const FileStore = require('./lib/file-store')
+const loadMigrationsIntoSet = require('./lib/load-migrations')
 
 /**
  * Expose the migrate function.
@@ -42,13 +42,13 @@ function migrate (title, up, down) {
 exports.MigrationSet = MigrationSet
 
 exports.load = function (options, fn) {
-  var opts = options || {}
+  const opts = options || {}
 
   // Create default store
-  var store = (typeof opts.stateStore === 'string') ? new FileStore(opts.stateStore) : opts.stateStore
+  const store = (typeof opts.stateStore === 'string') ? new FileStore(opts.stateStore) : opts.stateStore
 
   // Create migration set
-  var set = new MigrationSet(store)
+  const set = new MigrationSet(store)
 
   loadMigrationsIntoSet({
     set: set,

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var fs = require('fs')
+const fs = require('fs')
 
 module.exports = FileStore
 
@@ -44,7 +44,7 @@ FileStore.prototype.load = function (fn) {
     }
 
     // Check if old format and convert if needed
-    if (!store.hasOwnProperty('lastRun') && store.hasOwnProperty('pos')) {
+    if (!Object.prototype.hasOwnProperty.call(store, 'lastRun') && Object.prototype.hasOwnProperty.call(store, 'pos')) {
       if (store.pos === 0) {
         store.lastRun = null
       } else {
@@ -64,7 +64,7 @@ FileStore.prototype.load = function (fn) {
     }
 
     // Check if does not have required properties
-    if (!store.hasOwnProperty('lastRun') || !store.hasOwnProperty('migrations')) {
+    if (!Object.prototype.hasOwnProperty.call(store, 'lastRun') || !Object.prototype.hasOwnProperty.call(store, 'migrations')) {
       return fn(new Error('Invalid store file'))
     }
 

--- a/lib/load-migrations.js
+++ b/lib/load-migrations.js
@@ -1,12 +1,12 @@
 'use strict'
 
 var path = require('path')
-var fs = require('fs')
+var fs = require('fs').promises
 var Migration = require('./migration')
 
 module.exports = loadMigrationsIntoSet
 
-function loadMigrationsIntoSet (options, fn) {
+function loadMigrationsIntoSet(options, fn) {
   // Process options, set and store are required, rest optional
   var opts = options || {}
   if (!opts.set || !opts.store) {
@@ -22,39 +22,48 @@ function loadMigrationsIntoSet (options, fn) {
   }
 
   // Load from migrations store first up
-  store.load(function (err, state) {
+  store.load(async function (err, state) {
     if (err) return fn(err)
 
-    // Set last run date on the set
-    set.lastRun = state.lastRun || null
+    try {
+      // Set last run date on the set
+      set.lastRun = state.lastRun || null
 
-    // Read migrations directory
-    fs.readdir(migrationsDirectory, function (err, files) {
-      if (err) return fn(err)
+      // Read migrations directory
+      let files = await fs.readdir(migrationsDirectory)
 
       // Filter out non-matching files
       files = files.filter(filterFn)
 
       // Create migrations, keep a lookup map for the next step
-      var migMap = {}
-      var migrations = files.map(function (file) {
+      const migMap = {}
+      const promises = files.map(async function (file) {
         // Try to load the migrations file
-        var mod
+        const filepath = path.join(migrationsDirectory, file)
+        let mod
         try {
-          mod = require(path.join(migrationsDirectory, file))
+          mod = require(filepath)
         } catch (e) {
-          return fn(e)
+          if (e.code === 'ERR_REQUIRE_ESM') {
+            mod = await import(filepath)
+          }
+          else {
+            throw e
+          }
         }
 
-        var migration = new Migration(file, mod.up, mod.down, mod.description)
+        const migration = new Migration(file, mod.up, mod.down, mod.description)
         migMap[file] = migration
         return migration
       })
+      let migrations = await Promise.all(promises)
 
       // Fill in timestamp from state, or error if missing
       state.migrations && state.migrations.forEach(function (m) {
         if (m.timestamp !== null && !migMap[m.title]) {
-          return ignoreMissing ? null : fn(new Error('Missing migration file: ' + m.title))
+          if (!ignoreMissing) {
+            throw new Error('Missing migration file: ' + m.title);
+          }
         } else if (!migMap[m.title]) {
           // Migration existed in state file, but was not run and not loadable
           return
@@ -70,6 +79,8 @@ function loadMigrationsIntoSet (options, fn) {
 
       // Successfully loaded
       fn()
-    })
+    } catch (e) {
+      fn(e)
+    }
   })
 }

--- a/lib/load-migrations.js
+++ b/lib/load-migrations.js
@@ -1,23 +1,23 @@
 'use strict'
 
-var path = require('path')
-var fs = require('fs').promises
-var Migration = require('./migration')
+const path = require('path')
+const fs = require('fs').promises
+const Migration = require('./migration')
 
 module.exports = loadMigrationsIntoSet
 
-function loadMigrationsIntoSet(options, fn) {
+function loadMigrationsIntoSet (options, fn) {
   // Process options, set and store are required, rest optional
-  var opts = options || {}
+  const opts = options || {}
   if (!opts.set || !opts.store) {
     throw new TypeError((opts.set ? 'store' : 'set') + ' is required for loading migrations')
   }
-  var set = opts.set
-  var store = opts.store
-  var ignoreMissing = !!opts.ignoreMissing
-  var migrationsDirectory = path.resolve(opts.migrationsDirectory || 'migrations')
-  var filterFn = opts.filterFunction || (() => true)
-  var sortFn = opts.sortFunction || function (m1, m2) {
+  const set = opts.set
+  const store = opts.store
+  const ignoreMissing = !!opts.ignoreMissing
+  const migrationsDirectory = path.resolve(opts.migrationsDirectory || 'migrations')
+  const filterFn = opts.filterFunction || (() => true)
+  const sortFn = opts.sortFunction || function (m1, m2) {
     return m1.title > m2.title ? 1 : (m1.title < m2.title ? -1 : 0)
   }
 
@@ -46,8 +46,7 @@ function loadMigrationsIntoSet(options, fn) {
         } catch (e) {
           if (e.code === 'ERR_REQUIRE_ESM') {
             mod = await import(filepath)
-          }
-          else {
+          } else {
             throw e
           }
         }
@@ -62,7 +61,7 @@ function loadMigrationsIntoSet(options, fn) {
       state.migrations && state.migrations.forEach(function (m) {
         if (m.timestamp !== null && !migMap[m.title]) {
           if (!ignoreMissing) {
-            throw new Error('Missing migration file: ' + m.title);
+            throw new Error('Missing migration file: ' + m.title)
           }
         } else if (!migMap[m.title]) {
           // Migration existed in state file, but was not run and not loadable

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,5 +1,5 @@
 'use strict'
-var chalk = require('chalk')
+const chalk = require('chalk')
 
 module.exports = function log (key, msg) {
   console.log('  ' + chalk.grey(key) + ' : ' + chalk.cyan(msg))

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -3,9 +3,9 @@
 module.exports = migrate
 
 function migrate (set, direction, migrationName, fn) {
-  var migrations = []
-  var lastRunIndex
-  var toIndex
+  let migrations = []
+  let lastRunIndex
+  let toIndex
 
   if (!migrationName) {
     toIndex = direction === 'up' ? set.migrations.length : 0
@@ -27,12 +27,12 @@ function migrate (set, direction, migrationName, fn) {
     }
 
     // Status for supporting promises and callbacks
-    var isPromise = false
+    let isPromise = false
 
     // Run the migration function
     set.emit('migration', migration, direction)
-    var arity = migration[direction].length
-    var returnValue = migration[direction](function (err) {
+    const arity = migration[direction].length
+    const returnValue = migration[direction](function (err) {
       if (isPromise) return set.emit('warning', 'if your migration returns a promise, do not call the done callback')
       completeMigration(err)
     })
@@ -115,8 +115,8 @@ function downMigrations (set, lastRunIndex, toIndex) {
  */
 
 function positionOfMigration (migrations, title) {
-  var lastTimestamp
-  for (var i = 0; i < migrations.length; ++i) {
+  let lastTimestamp
+  for (let i = 0; i < migrations.length; ++i) {
     lastTimestamp = migrations[i].timestamp ? i : lastTimestamp
     if (migrations[i].title === title) return i
   }

--- a/lib/register-compiler.js
+++ b/lib/register-compiler.js
@@ -1,12 +1,12 @@
 'use strict'
-var path = require('path')
+const path = require('path')
 
 module.exports = registerCompiler
 
 function registerCompiler (c) {
-  var compiler = c.split(':')
-  var ext = compiler[0]
-  var mod = compiler[1]
+  const compiler = c.split(':')
+  const ext = compiler[0]
+  let mod = compiler[1]
 
   if (mod[0] === '.') mod = path.join(process.cwd(), mod)
   require(mod)({

--- a/lib/set.js
+++ b/lib/set.js
@@ -10,10 +10,10 @@
  * Module dependencies.
  */
 
-var EventEmitter = require('events')
-var Migration = require('./migration')
-var migrate = require('./migrate')
-var inherits = require('inherits')
+const EventEmitter = require('events')
+const Migration = require('./migration')
+const migrate = require('./migrate')
+const inherits = require('inherits')
 
 /**
  * Expose `Set`.
@@ -52,7 +52,7 @@ inherits(MigrationSet, EventEmitter)
  */
 
 MigrationSet.prototype.addMigration = function (title, up, down) {
-  var migration
+  let migration
   if (!(title instanceof Migration)) {
     migration = new Migration(title, up, down)
   } else {

--- a/lib/template-generator.js
+++ b/lib/template-generator.js
@@ -1,51 +1,45 @@
 'use strict'
-var path = require('path')
-var fs = require('fs')
-var slug = require('slug')
-var formatDate = require('dateformat')
-var mkdirp = require('mkdirp')
+const path = require('path')
+const fs = require('fs').promises
+const slug = require('slug')
+const formatDate = require('dateformat')
+const mkdirp = require('mkdirp')
 
-module.exports = function templateGenerator (opts, cb) {
-  // Setup default options
-  opts = opts || {}
-  var name = opts.name
-  var dateFormat = opts.dateFormat
-  var templateFile = opts.templateFile || path.join(__dirname, 'template.js')
-  var migrationsDirectory = opts.migrationsDirectory || 'migrations'
-  var extension = opts.extension
+module.exports = async function templateGenerator (opts, cb) {
+  try {
+    // Setup default options
+    opts = opts || {}
+    const name = opts.name
+    const dateFormat = opts.dateFormat
+    const templateFile = opts.templateFile || path.join(__dirname, 'template.js')
+    const migrationsDirectory = opts.migrationsDirectory || 'migrations'
+    const extension = opts.extension
 
-  loadTemplate(templateFile, function (err, template) {
-    if (err) return cb(err)
-
+    const template = await loadTemplate(templateFile)
     // Ensure migrations directory exists
-    mkdirp(migrationsDirectory, function (err) {
-      if (err) return cb(err)
+    await mkdirp(migrationsDirectory)
+    // Create date string
+    const formattedDate = dateFormat ? formatDate(new Date(), dateFormat) : Date.now()
 
-      // Create date string
-      var formattedDate = dateFormat ? formatDate(new Date(), dateFormat) : Date.now()
+    // Fix up file path
+    const p = path.join(path.resolve(migrationsDirectory), slug(formattedDate + (name ? '-' + name : '')) + extension)
 
-      // Fix up file path
-      var p = path.join(path.resolve(migrationsDirectory), slug(formattedDate + (name ? '-' + name : '')) + extension)
-
-      // Write the template file
-      fs.writeFile(p, template, function (err) {
-        if (err) return cb(err)
-        cb(null, p)
-      })
-    })
-  })
+    // Write the template file
+    await fs.writeFile(p, template)
+    cb(null, p)
+  } catch (e) {
+    cb(e)
+  }
 }
 
-var _templateCache = {}
-function loadTemplate (tmpl, cb) {
+const _templateCache = {}
+
+async function loadTemplate (tmpl) {
   if (_templateCache[tmpl]) {
-    return cb(null, _templateCache)
+    return _templateCache[tmpl]
   }
-  fs.readFile(tmpl, {
-    encoding: 'utf8'
-  }, function (err, content) {
-    if (err) return cb(err)
-    _templateCache[tmpl] = content
-    cb(null, content)
-  })
+  const content = await fs.readFile(tmpl, { encoding: 'utf8' })
+
+  _templateCache[tmpl] = content
+  return content
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "migrate-down": "./bin/migrate-down"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
-    "rimraf": "^2.6.2",
-    "standard": "^12.0.1"
+    "mocha": "^8.2.1",
+    "rimraf": "^3.0.2",
+    "standard": "^16.0.3"
   },
   "main": "index",
   "engines": {
@@ -33,13 +33,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "chalk": "^2.4.1",
-    "commander": "^2.19.0",
-    "dateformat": "^3.0.3",
-    "dotenv": "^6.1.0",
-    "inherits": "^2.0.3",
+    "chalk": "^4.1.0",
+    "commander": "^7.0.0",
+    "dateformat": "^4.5.0",
+    "dotenv": "^8.2.0",
+    "inherits": "^2.0.4",
     "minimatch": "^3.0.4",
-    "mkdirp": "^0.5.1",
-    "slug": "^0.9.2"
+    "mkdirp": "^1.0.4",
+    "slug": "^4.0.2"
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -10,7 +10,7 @@ const BASE = path.join(__dirname, 'fixtures', 'basic')
 const STATE = path.join(BASE, '.migrate')
 
 describe('migration set', function () {
-  var set
+  let set
 
   function assertNoPets () {
     assert.strictEqual(db.pets.length, 0)
@@ -130,9 +130,9 @@ describe('migration set', function () {
       }
     )
 
-    var saved = 0
-    var migrations = []
-    var expectedMigrations = [
+    let saved = 0
+    let migrations = []
+    let expectedMigrations = [
       '1-add-guy-ferrets.js',
       '2-add-girl-ferrets.js',
       '3-add-emails.js',

--- a/test/cli.js
+++ b/test/cli.js
@@ -36,7 +36,7 @@ describe('$ migrate', function () {
   afterEach(reset)
 
   describe('init', function () {
-    beforeEach(mkdirp.bind(mkdirp, TMP_DIR))
+    beforeEach(() => mkdirp(TMP_DIR))
 
     it('should create a migrations directory', function (done) {
       init([], function (err, out, code) {
@@ -51,14 +51,14 @@ describe('$ migrate', function () {
   }) // end init
 
   describe('create', function () {
-    beforeEach(mkdirp.bind(mkdirp, TMP_DIR))
+    beforeEach(() => mkdirp(TMP_DIR))
 
     it('should create a fixture file', function (done) {
       create(['test'], function (err, out, code) {
         assert(!err)
-        assert.strictEqual(code, 0)
-        var file = out.split(':')[1].trim()
-        var content = fs.readFileSync(file, {
+        assert.strictEqual(code, 0, out)
+        const file = out.split(':')[1].trim()
+        const content = fs.readFileSync(file, {
           encoding: 'utf8'
         })
         assert(content)
@@ -69,9 +69,9 @@ describe('$ migrate', function () {
     })
 
     it('should respect the --date-format', function (done) {
-      var name = 'test'
-      var fmt = 'yyyy-mm-dd'
-      var now = formatDate(new Date(), fmt)
+      const name = 'test'
+      const fmt = 'yyyy-mm-dd'
+      const now = formatDate(new Date(), fmt)
 
       create([name, '-d', fmt], function (err, out, code) {
         assert(!err)
@@ -84,10 +84,10 @@ describe('$ migrate', function () {
     })
 
     it('should respect the --extension', function (done) {
-      var name = 'test'
-      var fmt = 'yyyy-mm-dd'
-      var ext = '.mjs'
-      var now = formatDate(new Date(), fmt)
+      const name = 'test'
+      const fmt = 'yyyy-mm-dd'
+      const ext = '.mjs'
+      const now = formatDate(new Date(), fmt)
 
       create([name, '-d', fmt, '-e', ext], function (err, out, code) {
         assert(!err)
@@ -120,8 +120,8 @@ describe('$ migrate', function () {
         assert(!err)
         assert.strictEqual(code, 0, out)
         assert(out.indexOf('create') !== -1)
-        var file = out.split(':')[1].trim()
-        var content = fs.readFileSync(file, {
+        const file = out.split(':')[1].trim()
+        const content = fs.readFileSync(file, {
           encoding: 'utf8'
         })
         assert(content.indexOf('test') !== -1)
@@ -143,7 +143,7 @@ describe('$ migrate', function () {
     it('should run up on multiple migrations', function (done) {
       up([], function (err, out, code) {
         assert(!err)
-        assert.strictEqual(code, 0)
+        assert.strictEqual(code, 0, out)
         db.load()
         assert(out.indexOf('up') !== -1)
         assert.strictEqual(db.numbers.length, 2)

--- a/test/file-store.js
+++ b/test/file-store.js
@@ -12,7 +12,7 @@ const INVALID_STORE_FILE = path.join(BASE, 'invalid-store')
 
 describe('FileStore tests', function () {
   it('should load store file', function (done) {
-    let store = new FileStore(MODERN_STORE_FILE)
+    const store = new FileStore(MODERN_STORE_FILE)
     store.load(function (err, store) {
       if (err) {
         return done(err)
@@ -26,7 +26,7 @@ describe('FileStore tests', function () {
   })
 
   it('should convert pre-v1 store file format', function (done) {
-    let store = new FileStore(OLD_STORE_FILE)
+    const store = new FileStore(OLD_STORE_FILE)
     store.load(function (err, store) {
       if (err) {
         return done(err)
@@ -45,7 +45,7 @@ describe('FileStore tests', function () {
   })
 
   it('should error with invalid store file format', function (done) {
-    let store = new FileStore(BAD_STORE_FILE)
+    const store = new FileStore(BAD_STORE_FILE)
     store.load(function (err, store) {
       if (!err) {
         return done(new Error('Error expected'))
@@ -58,7 +58,7 @@ describe('FileStore tests', function () {
   })
 
   it('should error with invalid pos', function (done) {
-    let store = new FileStore(INVALID_STORE_FILE)
+    const store = new FileStore(INVALID_STORE_FILE)
     store.load(function (err, store) {
       if (!err) {
         return done(new Error('Error expected'))

--- a/test/fixtures/basic/1-add-guy-ferrets.js
+++ b/test/fixtures/basic/1-add-guy-ferrets.js
@@ -1,5 +1,5 @@
 
-var db = require('../../util/db')
+const db = require('../../util/db')
 
 exports.description = 'Adds two pets'
 

--- a/test/fixtures/basic/2-add-girl-ferrets.js
+++ b/test/fixtures/basic/2-add-girl-ferrets.js
@@ -1,5 +1,5 @@
 
-var db = require('../../util/db')
+const db = require('../../util/db')
 
 exports.up = function (next) {
   db.pets.push({ name: 'jane' })

--- a/test/fixtures/basic/3-add-emails.js
+++ b/test/fixtures/basic/3-add-emails.js
@@ -1,5 +1,5 @@
 
-var db = require('../../util/db')
+const db = require('../../util/db')
 
 exports.up = function (next) {
   db.pets.forEach(function (pet) {

--- a/test/fixtures/env/migrations/1-add-guy-ferrets.js
+++ b/test/fixtures/env/migrations/1-add-guy-ferrets.js
@@ -1,4 +1,4 @@
-var db = require('../../../util/db')
+const db = require('../../../util/db')
 
 exports.up = function (next) {
   db[process.env.DB].push({ name: 'tobi' })

--- a/test/fixtures/env/migrations/2-add-girl-ferrets.js
+++ b/test/fixtures/env/migrations/2-add-girl-ferrets.js
@@ -1,4 +1,4 @@
-var db = require('../../../util/db')
+const db = require('../../../util/db')
 
 exports.up = function (next) {
   db[process.env.DB].push({ name: 'jane' })

--- a/test/fixtures/issue-33/1-migration.js
+++ b/test/fixtures/issue-33/1-migration.js
@@ -1,5 +1,5 @@
 
-var db = require('../../util/db')
+const db = require('../../util/db')
 
 exports.up = function (next) {
   db.issue33.push('1-up')

--- a/test/fixtures/issue-33/2-migration.js
+++ b/test/fixtures/issue-33/2-migration.js
@@ -1,5 +1,5 @@
 
-var db = require('../../util/db')
+const db = require('../../util/db')
 
 exports.up = function (next) {
   db.issue33.push('2-up')

--- a/test/fixtures/issue-33/3-migration.js
+++ b/test/fixtures/issue-33/3-migration.js
@@ -1,5 +1,5 @@
 
-var db = require('../../util/db')
+const db = require('../../util/db')
 
 exports.up = function (next) {
   db.issue33.push('3-up')

--- a/test/fixtures/numbers/migrations/1-one.js
+++ b/test/fixtures/numbers/migrations/1-one.js
@@ -1,5 +1,5 @@
-var assert = require('assert')
-var db = require('../../../util/db')
+const assert = require('assert')
+const db = require('../../../util/db')
 
 exports.up = function (next) {
   db.load()

--- a/test/fixtures/numbers/migrations/2-two.js
+++ b/test/fixtures/numbers/migrations/2-two.js
@@ -1,4 +1,4 @@
-var db = require('../../../util/db')
+const db = require('../../../util/db')
 
 exports.up = function (next) {
   db.load()

--- a/test/integration.js
+++ b/test/integration.js
@@ -75,7 +75,7 @@ describe('integration tests', function () {
           assert.strictEqual(code, 0)
 
           // Keep migration filename to remove
-          var filename = out.split(' : ')[1].trim()
+          const filename = out.split(' : ')[1].trim()
 
           run.up(TMP_DIR, [], function (err, out, code) {
             assert(!err)
@@ -115,7 +115,7 @@ describe('integration tests', function () {
           assert.strictEqual(code, 0)
 
           // Keep migration filename to remove
-          var filename = out.split(' : ')[1].trim()
+          const filename = out.split(' : ')[1].trim()
 
           run.up(TMP_DIR, [], function (err, out, code) {
             assert(!err)

--- a/test/issue-33.js
+++ b/test/issue-33.js
@@ -9,11 +9,11 @@ const db = require('./util/db')
 const BASE = path.join(__dirname, 'fixtures', 'issue-33')
 const STATE = path.join(BASE, '.migrate')
 
-var A1 = ['1-up', '2-up', '3-up']
-var A2 = A1.concat(['3-down', '2-down', '1-down'])
+const A1 = ['1-up', '2-up', '3-up']
+const A2 = A1.concat(['3-down', '2-down', '1-down'])
 
 describe('issue #33', function () {
-  var set
+  let set
 
   beforeEach(function (done) {
     migrate.load({

--- a/test/promises.js
+++ b/test/promises.js
@@ -9,7 +9,7 @@ const BASE = path.join(__dirname, 'fixtures', 'promises')
 const STATE = path.join(__dirname, 'fixtures', '.migrate')
 
 describe('Promise migrations', function () {
-  var set
+  let set
 
   beforeEach(function (done) {
     migrate.load({
@@ -40,7 +40,7 @@ describe('Promise migrations', function () {
   })
 
   it('should warn when using promise but still calling callback', function (done) {
-    var warned = false
+    let warned = false
     set.on('warning', function (msg) {
       assert(msg)
       warned = true
@@ -53,7 +53,7 @@ describe('Promise migrations', function () {
 
   it('should warn with no promise or callback', function (done) {
     set.up('3-callback-promise-test.js', function () {
-      var warned = false
+      let warned = false
       set.on('warning', function (msg) {
         assert(msg)
         warned = true

--- a/test/util/db.js
+++ b/test/util/db.js
@@ -1,8 +1,8 @@
-var fs = require('fs')
-var path = require('path')
-var rimraf = require('rimraf')
+const fs = require('fs')
+const path = require('path')
+const rimraf = require('rimraf')
 
-var DB_PATH = path.join(__dirname, 'test.db')
+const DB_PATH = path.join(__dirname, 'test.db')
 
 function init () {
   exports.pets = []
@@ -16,12 +16,13 @@ function nuke () {
 }
 
 function load () {
+  let c
   try {
-    var c = fs.readFileSync(DB_PATH, 'utf8')
+    c = fs.readFileSync(DB_PATH, 'utf8')
   } catch (e) {
     return
   }
-  var j = JSON.parse(c)
+  const j = JSON.parse(c)
   Object.keys(j).forEach(function (k) {
     exports[k] = j[k]
   })

--- a/test/util/run.js
+++ b/test/util/run.js
@@ -2,9 +2,9 @@
 const path = require('path')
 const spawn = require('child_process').spawn
 
-var run = module.exports = function run (cmd, dir, args, done) {
-  var p = spawn(cmd, ['-c', dir, ...args])
-  var out = ''
+const run = module.exports = function run (cmd, dir, args, done) {
+  const p = spawn(cmd, ['-c', dir, ...args])
+  let out = ''
   p.stdout.on('data', function (d) {
     out += d.toString('utf8')
   })


### PR DESCRIPTION
The first commit add support migrations with .ejs extension
But without upgrade dependencies (second commit) dynamical import for that does not supported with old version of standard (standard Parsing error: Unexpected token import).
So time to update everything...