### PR TITLE
Accept default exports for a custom Store

### DIFF
--- a/bin/migrate-down
+++ b/bin/migrate-down
@@ -46,7 +46,8 @@ if (program.compiler) {
 // Setup store
 if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
 
-const Store = require(program.store)
+const StoreImport = require(program.store)
+const Store = StoreImport.default || StoreImport
 const store = new Store(program.stateFile)
 
 // Load in migrations

--- a/bin/migrate-init
+++ b/bin/migrate-init
@@ -41,7 +41,8 @@ if (program.compiler) {
 // Setup store
 if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
 
-const Store = require(program.store)
+const StoreImport = require(program.store)
+const Store = StoreImport.default || StoreImport
 const store = new Store(program.stateFile)
 
 // Create migrations dir path

--- a/bin/migrate-list
+++ b/bin/migrate-list
@@ -52,7 +52,8 @@ if (program.compiler) {
 // Setup store
 if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
 
-const Store = require(program.store)
+const StoreImport = require(program.store)
+const Store = StoreImport.default || StoreImport
 const store = new Store(program.stateFile)
 
 // Load in migrations

--- a/bin/migrate-up
+++ b/bin/migrate-up
@@ -60,7 +60,8 @@ if (program.compiler) {
 // Setup store
 if (program.store[0] === '.') program.store = path.join(process.cwd(), program.store)
 
-const Store = require(program.store)
+const StoreImport = require(program.store)
+const Store = StoreImport.default || StoreImport
 const store = new Store(program.stateFile)
 
 // Call store init


### PR DESCRIPTION
This enables usage with typescript without having to resort to using a JS custom store implementation.

This PR fixes https://github.com/tj/node-migrate/issues/168