### PR TITLE
Fix missing ignoreMissing option in MigrationeOptions typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ type MigrationOptions = {
   set?: MigrationSet;
   stateStore?: string | FileStore;
   migrationsDirectory?: string;
+  ignoreMissing?: boolean;
   filterFunction?: (migration: string) => boolean;
   sortFunction?: (migration1: Migration, migration2: Migration) => boolean;
 };


### PR DESCRIPTION
This option is missing in the type definition file.