### PR TITLE
fix: migration name not existing

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -115,12 +115,8 @@ function downMigrations (set, lastRunIndex, toIndex) {
  */
 
 function positionOfMigration (migrations, title) {
-  let lastTimestamp = -1;
-  for (let i = 0; i < migrations.length; ++i) {
-    lastTimestamp = migrations[i].timestamp ? i : lastTimestamp
-    if (migrations[i].title === title) return i
-  }
+  const requestedMigration = migrations.find((migration) => migration.title.includes(title));
+  const indexOfRequestedMigration = migrations.indexOf(requestedMigration);
 
-  // If titled migration was missing use last timestamped
-  return lastTimestamp;
+  return indexOfRequestedMigration;
 }

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -115,12 +115,12 @@ function downMigrations (set, lastRunIndex, toIndex) {
  */
 
 function positionOfMigration (migrations, title) {
-  let lastTimestamp
+  let lastTimestamp = -1;
   for (let i = 0; i < migrations.length; ++i) {
     lastTimestamp = migrations[i].timestamp ? i : lastTimestamp
     if (migrations[i].title === title) return i
   }
 
   // If titled migration was missing use last timestamped
-  return lastTimestamp
+  return lastTimestamp;
 }


### PR DESCRIPTION
current behavior: running `migrate down non-existing-migration-name` will always run migrate down on the last migration instead of failing

after fix: running will throw the correct error