### PR TITLE
feat: migrations can be provided as a map of loaded modules

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -230,7 +230,7 @@ Calls the callback with a `Set` based on the options passed.  Options:
 
 - `set`: A set instance if you created your own
 - `stateStore`: A store instance to load and store migration state, or a string which is a path to the migration state file
-- `migrations`: An object where keys are migration file names and values are migration modules loaded with `require()`
+- `migrations`: An object where keys are migration names and values are migration objects
 - `migrationsDirectory`: The path to the migrations directory
 - `filterFunction`: A filter function which will be called for each file found in the migrations directory
 - `sortFunction`: A sort function to ensure migration order

--- a/Readme.md
+++ b/Readme.md
@@ -230,6 +230,7 @@ Calls the callback with a `Set` based on the options passed.  Options:
 
 - `set`: A set instance if you created your own
 - `stateStore`: A store instance to load and store migration state, or a string which is a path to the migration state file
+- `migrations`: An object where keys are migration file names and values are migration modules loaded with `require()`
 - `migrationsDirectory`: The path to the migrations directory
 - `filterFunction`: A filter function which will be called for each file found in the migrations directory
 - `sortFunction`: A sort function to ensure migration order

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import type { EventEmitter } from "events";
 type MigrationOptions = {
   set?: MigrationSet;
   stateStore?: string | FileStore;
+  migrationsMap?: { [key: string]: { up: Function, down: Function } };
   migrationsDirectory?: string;
   ignoreMissing?: boolean;
   filterFunction?: (migration: string) => boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import type { EventEmitter } from "events";
 type MigrationOptions = {
   set?: MigrationSet;
   stateStore?: string | FileStore;
-  migrationsMap?: { [key: string]: { up: Function, down: Function } };
+  migrations?: { [key: string]: { up: Function, down: Function } };
   migrationsDirectory?: string;
   ignoreMissing?: boolean;
   filterFunction?: (migration: string) => boolean;

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ exports.load = function (options, fn) {
   loadMigrationsIntoSet({
     set,
     store,
+    migrationsMap: opts.migrationsMap,
     migrationsDirectory: opts.migrationsDirectory,
     filterFunction: opts.filterFunction,
     sortFunction: opts.sortFunction,

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ exports.load = function (options, fn) {
   loadMigrationsIntoSet({
     set,
     store,
-    migrationsMap: opts.migrationsMap,
+    migrations: opts.migrations,
     migrationsDirectory: opts.migrationsDirectory,
     filterFunction: opts.filterFunction,
     sortFunction: opts.sortFunction,

--- a/lib/load-migrations.js
+++ b/lib/load-migrations.js
@@ -14,7 +14,8 @@ async function loadFromMigrationsDirectory (migrationsDirectory, filterFn) {
   // Filter out non-matching files
   files = files.filter(filterFn)
 
-  const migrationObjects = await Promise.all(files.map(async function (file) {
+  const migMap = {}
+  const promises = files.map(async function (file) {
     // Try to load the migrations file
     const filepath = path.join(migrationsDirectory, file)
     let mod
@@ -27,9 +28,12 @@ async function loadFromMigrationsDirectory (migrationsDirectory, filterFn) {
         throw e
       }
     }
-    return { [file]: new Migration(file, mod.up, mod.down, mod.description) }
-  }))
-  const migMap = Object.assign(...migrationObjects)
+
+    const migration = new Migration(file, mod.up, mod.down, mod.description)
+    migMap[file] = migration
+    return migration
+  })
+  await Promise.all(promises)
   return migMap
 }
 

--- a/lib/load-migrations.js
+++ b/lib/load-migrations.js
@@ -16,6 +16,7 @@ function loadMigrationsIntoSet (options, fn) {
   const set = opts.set
   const store = opts.store
   const ignoreMissing = !!opts.ignoreMissing
+  const migrationsMap = opts.migrationsMap
   const migrationsDirectory = path.resolve(opts.migrationsDirectory || 'migrations')
   const filterFn = opts.filterFunction || (() => true)
   const sortFn = opts.sortFunction || function (m1, m2) {
@@ -30,33 +31,45 @@ function loadMigrationsIntoSet (options, fn) {
       // Set last run date on the set
       set.lastRun = state.lastRun || null
 
-      // Read migrations directory
-      let files = await fs.readdir(migrationsDirectory)
-
-      // Filter out non-matching files
-      files = files.filter(filterFn)
-
       // Create migrations, keep a lookup map for the next step
       const migMap = {}
-      const promises = files.map(async function (file) {
-        // Try to load the migrations file
-        const filepath = path.join(migrationsDirectory, file)
-        let mod
-        try {
-          mod = require(filepath)
-        } catch (e) {
-          if (e.code === 'ERR_REQUIRE_ESM') {
-            mod = await import(url.pathToFileURL(filepath))
-          } else {
-            return fn(e)
-          }
-        }
 
-        const migration = new Migration(file, mod.up, mod.down, mod.description)
-        migMap[file] = migration
-        return migration
-      })
-      let migrations = await Promise.all(promises)
+      let migrations
+
+      if (migrationsMap) {
+        migrations = Object.keys(migrationsMap).map((migrationName) => {
+          const mod = migrationsMap[migrationName]
+          const migration = new Migration(migrationName, mod.up, mod.down, mod.description)
+          migMap[migrationName] = migration
+          return migration
+        })
+      } else {
+        // Read migrations directory
+        let files = await fs.readdir(migrationsDirectory)
+
+        // Filter out non-matching files
+        files = files.filter(filterFn)
+
+        const promises = files.map(async function (file) {
+          // Try to load the migrations file
+          const filepath = path.join(migrationsDirectory, file)
+          let mod
+          try {
+            mod = require(filepath)
+          } catch (e) {
+            if (e.code === 'ERR_REQUIRE_ESM') {
+              mod = await import(url.pathToFileURL(filepath))
+            } else {
+              return fn(e)
+            }
+          }
+
+          const migration = new Migration(file, mod.up, mod.down, mod.description)
+          migMap[file] = migration
+          return migration
+        })
+        migrations = await Promise.all(promises)
+      }
 
       // Fill in timestamp from state, or error if missing
       state.migrations && state.migrations.forEach(function (m) {

--- a/lib/load-migrations.js
+++ b/lib/load-migrations.js
@@ -55,11 +55,7 @@ function loadMigrationsIntoSet (options, fn) {
   const ignoreMissing = !!opts.ignoreMissing
   const migrations = opts.migrations
   const migrationsDirectory = path.resolve(opts.migrationsDirectory || 'migrations')
-
-  // filterFn :: String -> boolean
   const filterFn = opts.filterFunction || (() => true)
-
-  // sortFn :: Migration -> Integer
   const sortFn = opts.sortFunction || function (m1, m2) {
     return m1.title > m2.title ? 1 : (m1.title < m2.title ? -1 : 0)
   }

--- a/lib/load-migrations.js
+++ b/lib/load-migrations.js
@@ -33,12 +33,12 @@ async function loadFromMigrationsDirectory (migrationsDirectory, filterFn) {
   return migMap
 }
 
-function loadFromMigrationsMap (migrationsMap, filterFn) {
+function loadFromMigrations (migrations, filterFn) {
   return Object
-    .keys(migrationsMap)
+    .keys(migrations)
     .filter(filterFn)
     .reduce((migMap, migrationName) => {
-      const mod = migrationsMap[migrationName]
+      const mod = migrations[migrationName]
       migMap[migrationName] = new Migration(migrationName, mod.up, mod.down, mod.description)
       return migMap
     }, {})
@@ -53,7 +53,7 @@ function loadMigrationsIntoSet (options, fn) {
   const set = opts.set
   const store = opts.store
   const ignoreMissing = !!opts.ignoreMissing
-  const migrationsMap = opts.migrationsMap
+  const migrations = opts.migrations
   const migrationsDirectory = path.resolve(opts.migrationsDirectory || 'migrations')
 
   // filterFn :: String -> boolean
@@ -73,8 +73,8 @@ function loadMigrationsIntoSet (options, fn) {
       set.lastRun = state.lastRun || null
 
       // Create migrations, keep a lookup map for the next step
-      const migMap = (migrationsMap)
-        ? loadFromMigrationsMap(migrationsMap, filterFn)
+      const migMap = (migrations)
+        ? loadFromMigrations(migrations, filterFn)
         : await loadFromMigrationsDirectory(migrationsDirectory, filterFn)
 
       // Fill in timestamp from state, or error if missing

--- a/lib/load-migrations.js
+++ b/lib/load-migrations.js
@@ -7,6 +7,43 @@ const Migration = require('./migration')
 
 module.exports = loadMigrationsIntoSet
 
+async function loadFromMigrationsDirectory (migrationsDirectory, filterFn) {
+  // Read migrations directory
+  let files = await fs.readdir(migrationsDirectory)
+
+  // Filter out non-matching files
+  files = files.filter(filterFn)
+
+  const migrationObjects = await Promise.all(files.map(async function (file) {
+    // Try to load the migrations file
+    const filepath = path.join(migrationsDirectory, file)
+    let mod
+    try {
+      mod = require(filepath)
+    } catch (e) {
+      if (e.code === 'ERR_REQUIRE_ESM') {
+        mod = await import(url.pathToFileURL(filepath))
+      } else {
+        throw e
+      }
+    }
+    return { [file]: new Migration(file, mod.up, mod.down, mod.description) }
+  }))
+  const migMap = Object.assign(...migrationObjects)
+  return migMap
+}
+
+function loadFromMigrationsMap (migrationsMap, filterFn) {
+  return Object
+    .keys(migrationsMap)
+    .filter(filterFn)
+    .reduce((migMap, migrationName) => {
+      const mod = migrationsMap[migrationName]
+      migMap[migrationName] = new Migration(migrationName, mod.up, mod.down, mod.description)
+      return migMap
+    }, {})
+}
+
 function loadMigrationsIntoSet (options, fn) {
   // Process options, set and store are required, rest optional
   const opts = options || {}
@@ -18,7 +55,11 @@ function loadMigrationsIntoSet (options, fn) {
   const ignoreMissing = !!opts.ignoreMissing
   const migrationsMap = opts.migrationsMap
   const migrationsDirectory = path.resolve(opts.migrationsDirectory || 'migrations')
+
+  // filterFn :: String -> boolean
   const filterFn = opts.filterFunction || (() => true)
+
+  // sortFn :: Migration -> Integer
   const sortFn = opts.sortFunction || function (m1, m2) {
     return m1.title > m2.title ? 1 : (m1.title < m2.title ? -1 : 0)
   }
@@ -32,44 +73,9 @@ function loadMigrationsIntoSet (options, fn) {
       set.lastRun = state.lastRun || null
 
       // Create migrations, keep a lookup map for the next step
-      const migMap = {}
-
-      let migrations
-
-      if (migrationsMap) {
-        migrations = Object.keys(migrationsMap).filter(filterFn).map((migrationName) => {
-          const mod = migrationsMap[migrationName]
-          const migration = new Migration(migrationName, mod.up, mod.down, mod.description)
-          migMap[migrationName] = migration
-          return migration
-        })
-      } else {
-        // Read migrations directory
-        let files = await fs.readdir(migrationsDirectory)
-
-        // Filter out non-matching files
-        files = files.filter(filterFn)
-
-        const promises = files.map(async function (file) {
-          // Try to load the migrations file
-          const filepath = path.join(migrationsDirectory, file)
-          let mod
-          try {
-            mod = require(filepath)
-          } catch (e) {
-            if (e.code === 'ERR_REQUIRE_ESM') {
-              mod = await import(url.pathToFileURL(filepath))
-            } else {
-              return fn(e)
-            }
-          }
-
-          const migration = new Migration(file, mod.up, mod.down, mod.description)
-          migMap[file] = migration
-          return migration
-        })
-        migrations = await Promise.all(promises)
-      }
+      const migMap = (migrationsMap)
+        ? loadFromMigrationsMap(migrationsMap, filterFn)
+        : await loadFromMigrationsDirectory(migrationsDirectory, filterFn)
 
       // Fill in timestamp from state, or error if missing
       state.migrations && state.migrations.forEach(function (m) {
@@ -82,11 +88,10 @@ function loadMigrationsIntoSet (options, fn) {
         migMap[m.title].timestamp = m.timestamp
       })
 
-      // Sort the migrations by their title
-      migrations = migrations.sort(sortFn)
-
-      // Add the migrations to the set
-      migrations.forEach(set.addMigration.bind(set))
+      Object
+        .values(migMap)
+        .sort(sortFn)
+        .forEach(set.addMigration.bind(set))
 
       // Successfully loaded
       fn()

--- a/lib/load-migrations.js
+++ b/lib/load-migrations.js
@@ -37,7 +37,7 @@ function loadMigrationsIntoSet (options, fn) {
       let migrations
 
       if (migrationsMap) {
-        migrations = Object.keys(migrationsMap).map((migrationName) => {
+        migrations = Object.keys(migrationsMap).filter(filterFn).map((migrationName) => {
           const mod = migrationsMap[migrationName]
           const migration = new Migration(migrationName, mod.up, mod.down, mod.description)
           migMap[migrationName] = migration


### PR DESCRIPTION
Currently it's not possible to use `node-migrate` with packagers relying on static analysis (e.g. webpack) because they need to know all module and file dependencies during bundling. Unfortunately the `node-migrate` package is dynamically loading migration files in `lib/load-migrations.js` using `require(filepath)` where `filepath` is a variable hence webpack cannot infer during compile time what folders and files to include for bundling in the final output.

This small PR solves the problem by introducing a new `migrationsMap` property in the options that are provided to the `migrate.load(opts, cb)` function like so:
```javascript
const migrationsMap = {
  "1673460432335-create-users-table.js": require("../migrations/1673460432335-create-users-table"),
  "1675438233157-create-sales-table.js": require("../migrations/1675438233157-create-sales-table"),
}

migrate.load({ migrationsMap }, (err, set) => {
  // you callback code here
})
```
This way there is no need to scan the migrations directory to include the migration files dynamically since they are statically included in the migrationsMap so they will be included by the bundlers like webpack.

The `migrationsDirectory` is ignored for loading files when the `migrationsMap` option is provded.