### PR TITLE
chore: update repository to point to correct github repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "migrations"
   ],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
-  "repository": "git://github.com/visionmedia/node-migrate",
+  "repository": "git://github.com/tj/node-migrate",
   "bin": {
     "migrate": "./bin/migrate",
     "migrate-init": "./bin/migrate-init",


### PR DESCRIPTION
Fixes the repository url shown on npm to point to this repository

![image](https://github.com/user-attachments/assets/1aabac04-0470-4407-956c-4b1ac7ce50d5)
